### PR TITLE
Improve menu handling and CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,10 @@ This repository contains a Tkinter-based GUI application for plotting and analyz
    python bio_graph_app.py
    ```
 
+To exit the application, use **File → 終了** from the menu bar or close the window. The app now confirms before closing.
+
+Use the "CSVに保存..." button in the data table window to export processed data to a CSV file. If no sliced data is available, you'll be notified instead of saving an empty file.
+
+Presets now store the selected X/Y columns in addition to display settings so that you can easily reapply axis selections.
+
 The original Jupyter notebook is provided as `アオキ編集中-完成.ipynb`. It was converted to the standalone script `bio_graph_app.py` for easier execution.


### PR DESCRIPTION
## Summary
- refactor menu creation into a helper method
- confirm before closing the app via menu or window close
- prevent empty CSV export and warn the user
- document these improvements in README

## Testing
- `python -m py_compile bio_graph_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848c3c7f8d883229a5953f656052abd