### PR TITLE
Add main menu launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ This repository contains a Tkinter-based GUI application for plotting and analyz
    ```bash
    pip install openpyxl
    ```
-2. Run the application:
+2. Run the menu script to choose whether to integrate files or start the GUI:
+   ```bash
+   python main_menu.py
+   ```
+
+   You can still launch the GUI directly if desired:
    ```bash
    python bio_graph_app.py
    ```

--- a/main_menu.py
+++ b/main_menu.py
@@ -1,0 +1,28 @@
+import tkinter as tk
+from tkinter import messagebox
+
+from bio_graph_app import BioGraphApp
+import integrate_files
+
+
+def main():
+    # Create a temporary root window for the dialog
+    root = tk.Tk()
+    root.withdraw()
+
+    answer = messagebox.askquestion(
+        "Select Mode",
+        "Do you want to integrate files?\n\nYes: integrate files\nNo: launch GUI",
+    )
+    root.destroy()
+
+    if answer == 'yes':
+        integrate_files.integrate_files()
+    else:
+        gui_root = tk.Tk()
+        app = BioGraphApp(gui_root)
+        gui_root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `main_menu.py` to launch either the integration utility or the GUI
- document how to use the new menu in the README

## Testing
- `python -m py_compile main_menu.py bio_graph_app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a141bd32c8322a8c42b200184c28a